### PR TITLE
Workaround: Fix nan id

### DIFF
--- a/src/queries.py
+++ b/src/queries.py
@@ -673,7 +673,7 @@ def getDataAllocationOptimizer(indexer_id, network='mainnet', variables=None, ):
         API_GATEWAY = os.getenv('TESTNET_GATEWAY')
         OPTIMIZATION_DATA = """
         query MyQuery($input: String) {
-            subgraphDeployments {
+            subgraphDeployments (first: 1000){
             originalName
             signalledTokens
             stakedTokens


### PR DESCRIPTION
I found this issue when I tried to use this tool:

```
python3 ./main.py --indexer_id 0xb06071394531b63b0bac78f27e12dc2beaa913e4 --max_percentage 0.2 --threshold 20 --parallel_allocations 1 --no-subgraph-list
Script Execution on:  2021-10-05-15:07
                                                                                          Address  ... pending_rewards
id                                                                                                 ...                
NaN                                             0x5b83184ead3290c43e0a5524f086595e3ced90af300f...  ...    51452.020566
NaN                                             0xa3560688266a1f0b4f6151adbc4fd9628a4a0763daad...  ...    41214.069152
NaN                                             0x8e01ba7793e57b4f9a4e3d6c0c69e30f069347312977...  ...     2568.712742
QmTKXLEdMD6Vq7Nwxo8XAfnHpG6H1TzL1AGwiqLpoae3Pb  0x4a008334f8e7ea21be223d15462084f51abcc0e6625f...  ...    31864.981409
NaN                                             0xc064c354bc21dd958b1d41b67b8ef161b75d2246b425...  ...    39600.186295
NaN                                             0x6cbb3da0becfbdc8da2cbde7f47838743a8c8b46dfdc...  ...    43678.927278
NaN                                             0xbbde25a2c85f55b53b7698b9476610c3d1202d88870e...  ...    23646.147471
QmP9a8FEBkkt5SCvcRyv35denC2RFSfWGoL2tgoo8LHpPy  0x0c051d7783df72f62d041b0ebc22d7db55daf94d8bf7...  ...    10067.981451
QmTBxvMF6YnbT1eYeRx9XQpH4WvxTV53vdptCCZFiZSprg  0x4810cc7741423cec7e44fc7ec7a479e521453cbf090e...  ...     9317.064674
NaN                                             0xb55bbc726b026706840230d030e964a0e2b137aec50c...  ...    35921.743533
NaN                                             0xd533401c73a774da498821964c86e750a02811a2902f...  ...     4827.120178
NaN                                             0xf7a9deeb49deb2df41be159ed06802362b17792daddd...  ...   108479.628261
QmRDGLp6BHwiH9HAE2NYEE3f7LrKuRqziHBv76trT4etgU  0x2aaeb45afa62af1cc8f6d61decd5249429e0aaed6799...  ...    71573.073486
NaN                                             0x880544e3622bdd77cb265f0216ae3b35d3698b696315...  ...      643.829489

[14 rows x 13 columns]
Traceback (most recent call last):
  File "/home/bleiva/Repos/Protofire/thegraph-allocation-optimization/./main.py", line 11, in <module>
    optimizeAllocations(indexer_id=args.indexer_id, blacklist_parameter=args.blacklist,
  File "/home/bleiva/Repos/Protofire/thegraph-allocation-optimization/src/optimizer.py", line 274, in optimizeAllocations
    allocation_dict_log = df_log.to_dict(orient='index')
  File "/home/bleiva/Repos/Protofire/thegraph-allocation-optimization/env/lib64/python3.9/site-packages/pandas/core/frame.py", line 1607, in to_dict
    raise ValueError("DataFrame index must be unique for orient=

```

This is a workaround because at this moment we have almost 300 subgraphs in mainnet but the limit using graphql is 1000 per query. So it's necessary soon to implement a sorter method to get more than 1000 subgraphs.