### PR TITLE
Add missing dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,4 +50,6 @@ streamlit
 millify
 streamlit-lottie
 aiohttp
+python-dotenv
+psycopg2
 


### PR DESCRIPTION
Hit two errors when trying to get started:
### No module named 'dotenv'
```
Traceback (most recent call last):
  File "/.../src/anyblockanalytics/thegraph-allocation-optimization/./main.py", line 1, in <module>
    from src.helpers import initializeParser
  File "/.../src/anyblockanalytics/thegraph-allocation-optimization/src/helpers.py", line 3, in <module>
    from dotenv import load_dotenv
ModuleNotFoundError: No module named 'dotenv'
```

### No module named 'psycopg2'
```
Traceback (most recent call last):
  File "/.../src/anyblockanalytics/thegraph-allocation-optimization/./main.py", line 1, in <module>
    from src.helpers import initializeParser
  File "/.../src/anyblockanalytics/thegraph-allocation-optimization/src/helpers.py", line 4, in <module>
    import psycopg2
ModuleNotFoundError: No module named 'psycopg2'
```