### PR TITLE
remove duplicate df_log rows before casting to dict

### DIFF
--- a/src/optimizer.py
+++ b/src/optimizer.py
@@ -250,6 +250,11 @@ def optimizeAllocations(indexer_id, blacklist_parameter=True, parallel_allocatio
                        df_log['allocation_id']]
     df_log['pending_rewards'] = pending_rewards
 
+    # reset index to avoid this error:
+    #  ValueError: DataFrame index must be unique for orient='index'.
+    # see: https://stackoverflow.com/a/37580854
+    df_log.reset_index(drop=True, inplace=True)
+
     # Create Dictionary to convert to Json for Logging of Allocation Data
     allocation_dict_log = df_log.to_dict(orient='index')
     optimizer_results[current_datetime]['current_allocations'] = allocation_dict_log


### PR DESCRIPTION
I tried running main.py on a few indexers using the following invocation:

```
python ./main.py \
  --indexer_id $INDEXER_ADDRESS \
  --max_percentage 0.2 \
  --threshold 20 \
  --parallel_allocations 1 \
  --no-subgraph-list
```

But I hit the following error in the process:
```
Script Execution on:  2021-10-05-14:54
Traceback (most recent call last):
  File "/.../src/anyblockanalytics/thegraph-allocation-optimization/./main.py", line 11, in <module>
    optimizeAllocations(indexer_id=args.indexer_id, blacklist_parameter=args.blacklist,
  File "/.../src/anyblockanalytics/thegraph-allocation-optimization/src/optimizer.py", line 254, in optimizeAllocations
    allocation_dict_log = df_log.to_dict(orient='index')
  File "/.../.virtualenvs/thegraph-allocation-optimization/lib/python3.9/site-packages/pandas/core/frame.py", line 1607, in to_dict
    raise ValueError("DataFrame index must be unique for orient='index'.")
ValueError: DataFrame index must be unique for orient='index'.
```

Introducing the reset fixed it.