### PR TITLE
make default parallel allocations match help text

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -220,7 +220,7 @@ def initializeParser():
                            metavar='parallel_allocations',
                            type=int,
                            help='Amount of parallel Allocations per Subgraph. Defaults to 1.',
-                           default=2)
+                           default=1)
     # dedicate reserve stake that should not be considered in the allocation process
     my_parser.add_argument('--reserve_stake',
                            metavar='reserve_stake',


### PR DESCRIPTION
> Comments that contradict the code are worse than no comments


Seems like the default should be 1