### PR TITLE
fix main.py --help

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -212,7 +212,7 @@ def initializeParser():
     my_parser.add_argument('--threshold',
                            metavar='threshold',
                            type=float,
-                           help='Threshold for Updating the Allocations. How much more Indexing Rewards (in %) have to be \
+                           help='Threshold for Updating the Allocations. How much more Indexing Rewards (in %%) have to be \
                                 gained by the optimization to change the script. Supplied as a value between 0-100 ',
                            default=10.0)
     # amount of parallel allocations per Subgraph


### PR DESCRIPTION
Another small thing I ran into:

before the change:
```
$ python main.py --help
Traceback (most recent call last):
  File "/.../src/anyblockanalytics/thegraph-allocation-optimization/main.py", line 9, in <module>
    args = my_parser.parse_args()
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 1820, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 1853, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 2062, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 2002, in consume_optional
    take_action(action, args, option_string)
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 1930, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 1094, in __call__
    parser.print_help()
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 2550, in print_help
    self._print_message(self.format_help(), file)
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 2534, in format_help
    return formatter.format_help()
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 283, in format_help
    help = self._root_section.format_help()
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 214, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 214, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 214, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 214, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 530, in _format_action
    help_text = self._expand_help(action)
  File "/usr/local/Cellar/python@3.9/3.9.7/Frameworks/Python.framework/Versions/3.9/lib/python3.9/argparse.py", line 626, in _expand_help
    return self._get_help_string(action) % params
ValueError: unsupported format character ')' (0x29) at index 76
```


after the change:
```
usage: main.py [-h] [--indexer_id indexer_id] [--max_percentage max_percentage] [--threshold threshold] [--parallel_allocations parallel_allocations] [--reserve_stake reserve_stake]
               [--min_allocation min_allocation] [--min_allocated_grt_subgraph min_allocated_grt_subgraph] [--min_signalled_grt_subgraph min_signalled_grt_subgraph] [--subgraph-list] [--no-subgraph-list]
               [--blacklist] [--no-blacklist] [--slack_alerting] [--no-slack_alerting] [--threshold_interval threshold_interval] [--app app] [--network network]

The Graph Allocation script for determining the optimal Allocations across different Subgraphs. outputs a script.txt which an be used to allocate the results of the allocation script. The created Log Files logs
the run, with network information and if the threshold was reached. Different Parameters can be supplied.

optional arguments:
  -h, --help            show this help message and exit
  --indexer_id indexer_id
                        The Graph Indexer Address
  --max_percentage max_percentage
                        Max Percentage in relation to total allocations an Allocation for a subgraph is allowed to have. Supplied as a value between 0-1
  --threshold threshold
                        Threshold for Updating the Allocations. How much more Indexing Rewards (in %) have to be gained by the optimization to change the script. Supplied as a value between 0-100
  --parallel_allocations parallel_allocations
                        Amount of parallel Allocations per Subgraph. Defaults to 1.
  --reserve_stake reserve_stake
                        Amount of reserve_stake. Defaults to 0.
  --min_allocation min_allocation
                        Amount of reserve_stake. Defaults to 0.
  --min_allocated_grt_subgraph min_allocated_grt_subgraph
                        Amount of GRT allocated to subgraph to consider for Optimization else remove. Defaults to 100.
  --min_signalled_grt_subgraph min_signalled_grt_subgraph
                        Amount of GRT signaled to subgraph to consider for Optimization else remove. Defaults to 100.
  --subgraph-list
  --no-subgraph-list
  --blacklist
  --no-blacklist
  --slack_alerting
  --no-slack_alerting
  --threshold_interval threshold_interval
                        Set the Interval for Optimization and Threshold Calculation (Either "daily", or "weekly")
  --app app             Set the app execution (Either "script", or "web")
  --network network     Set Network either "mainnet" or "testnet"
```